### PR TITLE
feat: expose btclightclient query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@babylonlabs-io/babylon-proto-ts",
-  "version": "0.0.3-canary.4",
+  "version": "0.0.3-canary.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@babylonlabs-io/babylon-proto-ts",
-      "version": "0.0.3-canary.4",
+      "version": "0.0.3-canary.5",
       "license": "ISC",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babylonlabs-io/babylon-proto-ts",
-  "version": "0.0.3-canary.4",
+  "version": "0.0.3-canary.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,5 @@ export * as btcstakingpop from './generated/babylon/btcstaking/v1/pop';
 export * as btccheckpoint from './generated/babylon/btccheckpoint/v1/btccheckpoint';
 export * as incentivetx from './generated/babylon/incentive/tx';
 export * as incentivequery from './generated/babylon/incentive/query';
+export * as btclightclient from './generated/babylon/btclightclient/v1/btclightclient';
+export * as btclightclientquery from './generated/babylon/btclightclient/v1/query';


### PR DESCRIPTION
This is needed in order to fetch the BBN btc height, we will use this value to select the param.